### PR TITLE
Add FAISS-based vector store

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiogram==3.20.0.post0
 openai==1.82.0
+faiss-cpu

--- a/vector_store.py
+++ b/vector_store.py
@@ -1,39 +1,77 @@
-import math
-from typing import List
+import json
+import os
+from typing import List, Optional
 
+import faiss
+import numpy as np
 from openai import AsyncOpenAI
 
 
-class SimpleVectorStore:
-    """Very small in-memory vector store using OpenAI embeddings."""
+class FaissVectorStore:
+    """Vector store backed by FAISS and OpenAI embeddings."""
 
-    def __init__(self, client: AsyncOpenAI) -> None:
+    def __init__(self, client: AsyncOpenAI, max_size: int = 300) -> None:
         self.client = client
+        self.max_size = max_size
         self.embeddings: List[List[float]] = []
         self.texts: List[str] = []
+        self.index: Optional[faiss.IndexFlatL2] = None
 
     async def add(self, text: str) -> None:
         embedding = await self._embed(text)
         self.embeddings.append(embedding)
         self.texts.append(text)
+        if len(self.texts) > self.max_size:
+            self.embeddings.pop(0)
+            self.texts.pop(0)
+        self._rebuild_index()
 
     async def search(self, query: str, k: int = 3) -> List[str]:
-        if not self.embeddings:
+        if not self.texts:
             return []
         q_emb = await self._embed(query)
-        scores = [self._cosine_similarity(q_emb, emb) for emb in self.embeddings]
-        pairs = sorted(zip(scores, self.texts), reverse=True)
-        return [t for _, t in pairs[:k]]
+        self._ensure_index()
+        k = min(k, len(self.texts))
+        D, I = self.index.search(np.array([q_emb], dtype="float32"), k)
+        return [self.texts[i] for i in I[0] if i >= 0]
 
     async def _embed(self, text: str) -> List[float]:
-        resp = await self.client.embeddings.create(model="text-embedding-3-small", input=text)
+        resp = await self.client.embeddings.create(
+            model="text-embedding-3-small", input=text
+        )
         return resp.data[0].embedding
 
-    @staticmethod
-    def _cosine_similarity(a: List[float], b: List[float]) -> float:
-        dot = sum(x * y for x, y in zip(a, b))
-        norm_a = math.sqrt(sum(x * x for x in a))
-        norm_b = math.sqrt(sum(y * y for y in b))
-        if norm_a == 0 or norm_b == 0:
-            return 0.0
-        return dot / (norm_a * norm_b)
+    def _rebuild_index(self) -> None:
+        if not self.embeddings:
+            self.index = None
+            return
+        dim = len(self.embeddings[0])
+        self.index = faiss.IndexFlatL2(dim)
+        emb = np.array(self.embeddings, dtype="float32")
+        self.index.add(emb)
+
+    def _ensure_index(self) -> None:
+        if self.index is None:
+            self._rebuild_index()
+
+    def save(self, path: str) -> None:
+        self._ensure_index()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        faiss.write_index(self.index, path + ".index")
+        with open(path + ".json", "w") as f:
+            json.dump(self.texts, f)
+
+    @classmethod
+    def load(cls, client: AsyncOpenAI, path: str) -> "FaissVectorStore":
+        store = cls(client)
+        index_file = path + ".index"
+        texts_file = path + ".json"
+        if os.path.exists(index_file) and os.path.exists(texts_file):
+            store.index = faiss.read_index(index_file)
+            with open(texts_file) as f:
+                store.texts = json.load(f)
+            n = store.index.ntotal
+            if n:
+                vecs = store.index.reconstruct_n(0, n)
+                store.embeddings = vecs.tolist()
+        return store


### PR DESCRIPTION
## Summary
- use FAISS as the vector store backend
- keep per-user indexes under `data/{user_id}` and persist them
- update bot to use the new `FaissVectorStore`
- add `faiss-cpu` to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`